### PR TITLE
Add tool for fetching incident tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The MCP Zendesk integration provides the following functions:
 5. `zendesk_update_ticket` - Updates ticket properties
 6. `zendesk_add_private_note` - Adds an internal note to a ticket
 7. `zendesk_add_public_note` - Adds a public comment to a ticket
+8. `zendesk_get_linked_incidents` - Retrieves all incident tickets linked to a particular ticket
 
 ## Authentication Setup
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -342,4 +342,41 @@ export function zenDeskTools(server: McpServer) {
       }
     }
   );
+
+  server.tool(
+    "zendesk_get_linked_incidents",
+    "Fetch all incident tickets linked to a particular ticket",
+    {
+      ticket_id: z.string().describe("The ID of the ticket to retrieve linked incidents for"),
+    },
+    async ({ ticket_id }) => {
+      try {
+        const result = await new Promise((resolve, reject) => {
+          (client as any).tickets.listIncidents(parseInt(ticket_id, 10), (error: Error | undefined, req: any, result: any) => {
+            if (error) {
+              console.log(error);
+              reject(error);
+            } else {
+              resolve(result);
+            }
+          });
+        });
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(result, null, 2)
+          }]
+        };
+      } catch (error: any) {
+        return {
+          content: [{
+            type: "text",
+            text: `Error: ${error.message || 'Unknown error occurred'}`
+          }],
+          isError: true
+        };
+      }
+    }
+  );
 }


### PR DESCRIPTION
As part of Ticket Duty triaging, we may at times turn to incident tickets for:
* fetching details that may be missed from account managers
* scrape for additional cues/clues to further the investigation

The following changeset adds an MCP tool for fetching incident tickets