### PR TITLE
feat: add X-ZD-MCP-Server custom header to identify MCP server requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zd-mcp-server",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Zendesk MCP Server - Model Context Protocol server for Zendesk Support integration",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsc --watch",
+    "test": "vitest run",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,15 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  // Send an initial log message to satisfy the logging capability contract
+  // and confirm the server is ready.
+  await (server as any).server.sendLoggingMessage({
+    level: "info",
+    data: `Zendesk MCP Server v${VERSION} ready`,
+    logger: "zd-mcp-server",
+  });
+
   console.error(`Zendesk MCP Server v${VERSION} running on stdio`);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { SetLevelRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { zenDeskTools, createZendeskClient, searchTickets, getTicket, getTicketDetails, getLinkedIncidents } from "./tools/index.js";
 
 // Re-export the functions for library usage
@@ -32,6 +33,14 @@ async function main() {
   );
 
   zenDeskTools(server);
+
+  // Handle logging/setLevel requests from the client (e.g. MCP Inspector).
+  // The low-level Server validates the capability; we just need a handler
+  // that acknowledges the request — sendLoggingMessage already respects
+  // the level filtering internally.
+  (server as any).server.setRequestHandler(SetLevelRequestSchema, async () => {
+    return {};
+  });
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Stub env vars before the module is imported so the top-level guard doesn't throw
+vi.stubEnv("ZENDESK_EMAIL", "test@example.com");
+vi.stubEnv("ZENDESK_TOKEN", "abc123");
+vi.stubEnv("ZENDESK_SUBDOMAIN", "testdomain");
+
+vi.mock("node-zendesk", () => ({
+  default: {
+    createClient: vi.fn().mockReturnValue({}),
+  },
+}));
+
+describe("ZENDESK_CLIENT_HEADERS", () => {
+  it("includes the X-Zendesk-Client header", async () => {
+    const { ZENDESK_CLIENT_HEADERS } = await import("./index.js");
+    expect(ZENDESK_CLIENT_HEADERS["X-Zendesk-Client"]).toBe("zd-mcp-server");
+  });
+});
+
+describe("createZendeskClient", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("passes customHeaders to createClient", async () => {
+    const { createZendeskClient, ZENDESK_CLIENT_HEADERS } = await import("./index.js");
+    const zendesk = (await import("node-zendesk")).default;
+
+    createZendeskClient({
+      email: "test@example.com",
+      token: "abc123",
+      subdomain: "testdomain",
+    });
+
+    const callArg = vi.mocked(zendesk.createClient).mock.calls[0][0] as any;
+    expect(callArg.customHeaders).toEqual(ZENDESK_CLIENT_HEADERS);
+  });
+
+  it("passes X-Zendesk-Client header value to createClient", async () => {
+    const { createZendeskClient } = await import("./index.js");
+    const zendesk = (await import("node-zendesk")).default;
+
+    createZendeskClient({
+      email: "test@example.com",
+      token: "abc123",
+      subdomain: "testdomain",
+    });
+
+    const callArg = vi.mocked(zendesk.createClient).mock.calls[0][0] as any;
+    expect(callArg.customHeaders["X-Zendesk-Client"]).toBe("zd-mcp-server");
+  });
+});

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -48,13 +48,18 @@ describe("env-based client", () => {
   });
 
   it("is initialised with the X-ZD-MCP-Server custom header", async () => {
-    // Importing the module triggers the env-based createClient call at the top level
-    await import("./index.js");
+    // Get a reference to the mock BEFORE importing index.js so we capture
+    // the createClient call that fires at module load time, then clear any
+    // prior calls so only the env-client instantiation is counted.
     const zendesk = (await import("node-zendesk")).default;
+    vi.mocked(zendesk.createClient).mockClear();
 
+    // Importing index.js triggers the module-level createClient call
     const { ZENDESK_CLIENT_HEADERS } = await import("./index.js");
 
-    const envClientCall = vi.mocked(zendesk.createClient).mock.calls[0][0] as any;
-    expect(envClientCall.customHeaders).toEqual(ZENDESK_CLIENT_HEADERS);
+    // Should have been called exactly once for the env-based client
+    expect(vi.mocked(zendesk.createClient)).toHaveBeenCalledOnce();
+    const callArg = vi.mocked(zendesk.createClient).mock.calls[0][0] as any;
+    expect(callArg.customHeaders).toEqual(ZENDESK_CLIENT_HEADERS);
   });
 });

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,20 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Stub env vars before the module is imported so the top-level guard doesn't throw
-vi.stubEnv("ZENDESK_EMAIL", "test@example.com");
-vi.stubEnv("ZENDESK_TOKEN", "abc123");
-vi.stubEnv("ZENDESK_SUBDOMAIN", "testdomain");
-
 vi.mock("node-zendesk", () => ({
   default: {
     createClient: vi.fn().mockReturnValue({}),
   },
 }));
 
+// Stub env vars so the module-level guard and env-based client don't throw
+vi.stubEnv("ZENDESK_EMAIL", "test@example.com");
+vi.stubEnv("ZENDESK_TOKEN", "abc123");
+vi.stubEnv("ZENDESK_SUBDOMAIN", "testdomain");
+
 describe("ZENDESK_CLIENT_HEADERS", () => {
-  it("includes the X-Zendesk-Client header", async () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("includes the X-ZD-MCP-Server header", async () => {
     const { ZENDESK_CLIENT_HEADERS } = await import("./index.js");
-    expect(ZENDESK_CLIENT_HEADERS["X-Zendesk-Client"]).toBe("zd-mcp-server");
+    expect(ZENDESK_CLIENT_HEADERS["X-ZD-MCP-Server"]).toBe("zd-mcp-server");
   });
 });
 
@@ -23,7 +27,7 @@ describe("createZendeskClient", () => {
     vi.resetModules();
   });
 
-  it("passes customHeaders to createClient", async () => {
+  it("passes X-ZD-MCP-Server custom header to createClient", async () => {
     const { createZendeskClient, ZENDESK_CLIENT_HEADERS } = await import("./index.js");
     const zendesk = (await import("node-zendesk")).default;
 
@@ -36,18 +40,21 @@ describe("createZendeskClient", () => {
     const callArg = vi.mocked(zendesk.createClient).mock.calls[0][0] as any;
     expect(callArg.customHeaders).toEqual(ZENDESK_CLIENT_HEADERS);
   });
+});
 
-  it("passes X-Zendesk-Client header value to createClient", async () => {
-    const { createZendeskClient } = await import("./index.js");
+describe("env-based client", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("is initialised with the X-ZD-MCP-Server custom header", async () => {
+    // Importing the module triggers the env-based createClient call at the top level
+    await import("./index.js");
     const zendesk = (await import("node-zendesk")).default;
 
-    createZendeskClient({
-      email: "test@example.com",
-      token: "abc123",
-      subdomain: "testdomain",
-    });
+    const { ZENDESK_CLIENT_HEADERS } = await import("./index.js");
 
-    const callArg = vi.mocked(zendesk.createClient).mock.calls[0][0] as any;
-    expect(callArg.customHeaders["X-Zendesk-Client"]).toBe("zd-mcp-server");
+    const envClientCall = vi.mocked(zendesk.createClient).mock.calls[0][0] as any;
+    expect(envClientCall.customHeaders).toEqual(ZENDESK_CLIENT_HEADERS);
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,10 +5,14 @@ import { z } from "zod";
 
 // Custom headers sent with every request to Zendesk so that the MCP server
 // can be identified in API logs and audit trails.
-// `@types/node-zendesk` does not yet declare `customHeaders` on ClientOptions,
-// so we cast to `any` when calling createClient until the upstream types are updated.
+// `@types/node-zendesk` does not yet declare `customHeaders` on ClientOptions;
+// we extend the type locally until upstream types are updated.
+interface ZendeskClientOptions extends ZendeskTypes.ClientOptions {
+  customHeaders?: Record<string, string>;
+}
+
 export const ZENDESK_CLIENT_HEADERS: Record<string, string> = {
-  "X-Zendesk-Client": "zd-mcp-server",
+  "X-ZD-MCP-Server": "zd-mcp-server",
 };
 
 // Types for exported functions
@@ -20,12 +24,13 @@ export interface ZendeskConfig {
 
 // Create Zendesk client
 export function createZendeskClient(config: ZendeskConfig) {
-  return zendesk.createClient({
+  const options: ZendeskClientOptions = {
     username: config.email,
     token: config.token,
     remoteUri: `https://${config.subdomain}.zendesk.com/api/v2`,
     customHeaders: ZENDESK_CLIENT_HEADERS,
-  } as any);
+  };
+  return zendesk.createClient(options as ZendeskTypes.ClientOptions);
 }
 
 // Exported read-only tool functions
@@ -90,12 +95,11 @@ if (!process.env.ZENDESK_EMAIL || !process.env.ZENDESK_TOKEN || !process.env.ZEN
   throw new Error('Missing required environment variables: ZENDESK_EMAIL, ZENDESK_TOKEN, ZENDESK_SUBDOMAIN');
 }
 
-const client = zendesk.createClient({
-  username: process.env.ZENDESK_EMAIL as string,
-  token: process.env.ZENDESK_TOKEN as string,
-  remoteUri: `https://${process.env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2`,
-  customHeaders: ZENDESK_CLIENT_HEADERS,
-} as any);
+const client = createZendeskClient({
+  email: process.env.ZENDESK_EMAIL,
+  token: process.env.ZENDESK_TOKEN,
+  subdomain: process.env.ZENDESK_SUBDOMAIN,
+});
 
 export function zenDeskTools(server: McpServer) {
   server.tool(

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,14 @@ import zendesk from "node-zendesk";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+// Custom headers sent with every request to Zendesk so that the MCP server
+// can be identified in API logs and audit trails.
+// `@types/node-zendesk` does not yet declare `customHeaders` on ClientOptions,
+// so we cast to `any` when calling createClient until the upstream types are updated.
+export const ZENDESK_CLIENT_HEADERS: Record<string, string> = {
+  "X-Zendesk-Client": "zd-mcp-server",
+};
+
 // Types for exported functions
 export interface ZendeskConfig {
   email: string;
@@ -16,7 +24,8 @@ export function createZendeskClient(config: ZendeskConfig) {
     username: config.email,
     token: config.token,
     remoteUri: `https://${config.subdomain}.zendesk.com/api/v2`,
-  });
+    customHeaders: ZENDESK_CLIENT_HEADERS,
+  } as any);
 }
 
 // Exported read-only tool functions
@@ -85,7 +94,8 @@ const client = zendesk.createClient({
   username: process.env.ZENDESK_EMAIL as string,
   token: process.env.ZENDESK_TOKEN as string,
   remoteUri: `https://${process.env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2`,
-});
+  customHeaders: ZENDESK_CLIENT_HEADERS,
+} as any);
 
 export function zenDeskTools(server: McpServer) {
   server.tool(

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -101,6 +101,20 @@ const client = createZendeskClient({
   subdomain: process.env.ZENDESK_SUBDOMAIN,
 });
 
+// Helper to send log messages via the underlying low-level Server instance.
+// McpServer wraps Server as `server.server`; sendLoggingMessage lives there.
+async function log(
+  server: McpServer,
+  level: "debug" | "info" | "warning" | "error",
+  message: string
+) {
+  try {
+    await (server as any).server.sendLoggingMessage({ level, data: message, logger: "zd-mcp-server" });
+  } catch {
+    // Client may not have a logging handler connected yet; swallow silently.
+  }
+}
+
 export function zenDeskTools(server: McpServer) {
   server.tool(
     "zendesk_get_ticket",
@@ -109,9 +123,9 @@ export function zenDeskTools(server: McpServer) {
       ticket_id: z.string().describe("The ID of the ticket to retrieve"),
     },
     async ({ ticket_id }) => {
+      await log(server, "info", `zendesk_get_ticket: fetching ticket ${ticket_id}`);
       try {
         const result = await getTicket(client, parseInt(ticket_id, 10));
-
         return {
           content: [{
             type: "text",
@@ -119,6 +133,7 @@ export function zenDeskTools(server: McpServer) {
           }]
         };
       } catch (error: any) {
+        await log(server, "error", `zendesk_get_ticket: failed for ticket ${ticket_id} — ${error.message}`);
         return {
           content: [{
             type: "text",
@@ -143,6 +158,7 @@ export function zenDeskTools(server: McpServer) {
       tags: z.array(z.string()).optional().describe("Tags to set on the ticket (replaces existing tags)")
     },
     async ({ ticket_id, subject, status, priority, type, assignee_id, tags }) => {
+      await log(server, "info", `zendesk_update_ticket: updating ticket ${ticket_id}`);
       try {
         const ticketData: any = {
           ticket: {}
@@ -159,7 +175,6 @@ export function zenDeskTools(server: McpServer) {
         const result = await new Promise((resolve, reject) => {
           (client as any).tickets.update(parseInt(ticket_id, 10), ticketData, (error: Error | undefined, req: any, result: any) => {
             if (error) {
-              console.log(error);
               reject(error);
             } else {
               resolve(result);
@@ -174,6 +189,7 @@ export function zenDeskTools(server: McpServer) {
           }]
         };
       } catch (error: any) {
+        await log(server, "error", `zendesk_update_ticket: failed for ticket ${ticket_id} — ${error.message}`);
         return {
           content: [{
             type: "text",
@@ -197,6 +213,7 @@ export function zenDeskTools(server: McpServer) {
       tags: z.array(z.string()).optional().describe("Tags to add to the ticket")
     },
     async ({ subject, description, priority, status, type, tags }) => {
+      await log(server, "info", `zendesk_create_ticket: creating ticket with subject "${subject}"`);
       try {
         const ticketData: any = {
           ticket: {
@@ -213,7 +230,6 @@ export function zenDeskTools(server: McpServer) {
         const result = await new Promise((resolve, reject) => {
           (client as any).tickets.create(ticketData, (error: Error | undefined, req: any, result: any) => {
             if (error) {
-              console.log(error);
               reject(error);
             } else {
               resolve(result);
@@ -228,6 +244,7 @@ export function zenDeskTools(server: McpServer) {
           }]
         };
       } catch (error: any) {
+        await log(server, "error", `zendesk_create_ticket: failed — ${error.message}`);
         return {
           content: [{
             type: "text",
@@ -247,6 +264,7 @@ export function zenDeskTools(server: McpServer) {
       note: z.string().describe("The content of the private note")
     },
     async ({ ticket_id, note }) => {
+      await log(server, "info", `zendesk_add_private_note: adding note to ticket ${ticket_id}`);
       try {
         const result = await new Promise((resolve, reject) => {
           (client as any).tickets.update(parseInt(ticket_id, 10), {
@@ -258,7 +276,6 @@ export function zenDeskTools(server: McpServer) {
             }
           }, (error: Error | undefined, req: any, result: any) => {
             if (error) {
-              console.log(error);
               reject(error);
             } else {
               resolve(result);
@@ -273,6 +290,7 @@ export function zenDeskTools(server: McpServer) {
           }]
         };
       } catch (error: any) {
+        await log(server, "error", `zendesk_add_private_note: failed for ticket ${ticket_id} — ${error.message}`);
         return {
           content: [{
             type: "text",
@@ -292,6 +310,7 @@ export function zenDeskTools(server: McpServer) {
       comment: z.string().describe("The content of the public comment")
     },
     async ({ ticket_id, comment }) => {
+      await log(server, "info", `zendesk_add_public_note: adding comment to ticket ${ticket_id}`);
       try {
         const result = await new Promise((resolve, reject) => {
           (client as any).tickets.update(parseInt(ticket_id, 10), {
@@ -303,7 +322,6 @@ export function zenDeskTools(server: McpServer) {
             }
           }, (error: Error | undefined, req: any, result: any) => {
             if (error) {
-              console.log(error);
               reject(error);
             } else {
               resolve(result);
@@ -318,6 +336,7 @@ export function zenDeskTools(server: McpServer) {
           }]
         };
       } catch (error: any) {
+        await log(server, "error", `zendesk_add_public_note: failed for ticket ${ticket_id} — ${error.message}`);
         return {
           content: [{
             type: "text",
@@ -336,9 +355,9 @@ export function zenDeskTools(server: McpServer) {
       query: z.string().describe("Search query (e.g., 'status:open', 'priority:urgent', 'tags:need_help')"),
     },
     async ({ query }) => {
+      await log(server, "info", `zendesk_search: query "${query}"`);
       try {
         const result = await searchTickets(client, query);
-
         return {
           content: [{
             type: "text",
@@ -346,6 +365,7 @@ export function zenDeskTools(server: McpServer) {
           }]
         };
       } catch (error: any) {
+        await log(server, "error", `zendesk_search: failed — ${error.message}`);
         return {
           content: [{
             type: "text",
@@ -364,9 +384,9 @@ export function zenDeskTools(server: McpServer) {
       ticket_id: z.string().describe("The ID of the ticket to retrieve details for"),
     },
     async ({ ticket_id }) => {
+      await log(server, "info", `zendesk_get_ticket_details: fetching details for ticket ${ticket_id}`);
       try {
         const result = await getTicketDetails(client, parseInt(ticket_id, 10));
-
         return {
           content: [{
             type: "text",
@@ -374,6 +394,7 @@ export function zenDeskTools(server: McpServer) {
           }]
         };
       } catch (error: any) {
+        await log(server, "error", `zendesk_get_ticket_details: failed for ticket ${ticket_id} — ${error.message}`);
         return {
           content: [{
             type: "text",
@@ -392,9 +413,9 @@ export function zenDeskTools(server: McpServer) {
       ticket_id: z.string().describe("The ID of the ticket to retrieve linked incidents for"),
     },
     async ({ ticket_id }) => {
+      await log(server, "info", `zendesk_get_linked_incidents: fetching incidents for ticket ${ticket_id}`);
       try {
         const result = await getLinkedIncidents(client, parseInt(ticket_id, 10));
-
         return {
           content: [{
             type: "text",
@@ -402,6 +423,7 @@ export function zenDeskTools(server: McpServer) {
           }]
         };
       } catch (error: any) {
+        await log(server, "error", `zendesk_get_linked_incidents: failed for ticket ${ticket_id} — ${error.message}`);
         return {
           content: [{
             type: "text",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {
-    globals: true,
-  },
+  test: {},
 });


### PR DESCRIPTION
## Summary
Adds a custom `X-ZD-MCP-Server` header to every request made to the Zendesk API, so requests originating from this MCP server can be identified in Zendesk API logs and audit trails. Also wires up the MCP logging capability so tool invocations and errors are visible in the Inspector and any MCP client that supports logging.

## Changes
- Exports `ZENDESK_CLIENT_HEADERS` constant with `X-ZD-MCP-Server: zd-mcp-server` header
- Introduces `ZendeskClientOptions` interface extending `ClientOptions` with `customHeaders?` — narrows the cast instead of `as any` on the whole options object
- Deduplicates client instantiation: env-based module-level client delegates to `createZendeskClient()`
- Wires up MCP `logging` capability: all 7 tool handlers emit `info` on invocation and `error` on failure via `sendLoggingMessage`
- Registers `logging/setLevel` request handler so clients (e.g. MCP Inspector) can set log level without errors
- Sends a startup log message after `connect()` confirming the server is ready
- Removes `console.log(error)` calls that were leaking to stderr
- Bumps version `0.5.0` → `0.6.0` (semver minor — additive, backwards-compatible)
- Adds vitest tests covering the header constant, `createZendeskClient()`, and the env-based client initialisation

## Test Plan
- `npm test` — 3 tests pass
- `npx tsc --noEmit` — clean
- Tested end-to-end in MCP Inspector — logging tab shows messages, no capability warnings

## Notes
- `@types/node-zendesk` does not declare `customHeaders` on `ClientOptions`; the local interface extension handles this until upstream types are updated
- Follow-up PR planned: upgrade `node-zendesk` v2 → v6 (requires callback → async/await migration and `remoteUri` → `endpointUri` rename)