### PR TITLE
fix: send identifying User-Agent header to Zendesk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zd-mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Zendesk MCP Server - Model Context Protocol server for Zendesk Support integration",
   "main": "dist/index.js",
   "bin": {

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -16,9 +16,9 @@ describe("ZENDESK_CLIENT_HEADERS", () => {
     vi.resetModules();
   });
 
-  it("includes the X-ZD-MCP-Server header", async () => {
+  it("sets a User-Agent identifying the MCP server", async () => {
     const { ZENDESK_CLIENT_HEADERS } = await import("./index.js");
-    expect(ZENDESK_CLIENT_HEADERS["X-ZD-MCP-Server"]).toBe("zd-mcp-server");
+    expect(ZENDESK_CLIENT_HEADERS["User-Agent"]).toMatch(/^zd-mcp-server\//);
   });
 });
 
@@ -27,7 +27,7 @@ describe("createZendeskClient", () => {
     vi.resetModules();
   });
 
-  it("passes X-ZD-MCP-Server custom header to createClient", async () => {
+  it("passes the User-Agent custom header to createClient", async () => {
     const { createZendeskClient, ZENDESK_CLIENT_HEADERS } = await import("./index.js");
     const zendesk = (await import("node-zendesk")).default;
 
@@ -47,7 +47,7 @@ describe("env-based client", () => {
     vi.resetModules();
   });
 
-  it("is initialised with the X-ZD-MCP-Server custom header", async () => {
+  it("is initialised with the User-Agent custom header", async () => {
     // Get a reference to the mock BEFORE importing index.js so we capture
     // the createClient call that fires at module load time, then clear any
     // prior calls so only the env-client instantiation is counted.

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,17 +2,42 @@ import type * as ZendeskTypes from "node-zendesk";
 import zendesk from "node-zendesk";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 
 // Custom headers sent with every request to Zendesk so that the MCP server
-// can be identified in API logs and audit trails.
+// can be identified in API logs and audit trails. We override the default
+// `User-Agent` set by node-zendesk so requests are clearly attributable to
+// this MCP server.
 // `@types/node-zendesk` does not yet declare `customHeaders` on ClientOptions;
 // we extend the type locally until upstream types are updated.
 interface ZendeskClientOptions extends ZendeskTypes.ClientOptions {
   customHeaders?: Record<string, string>;
 }
 
+// Resolve the package version at runtime by reading the bundled `package.json`.
+// `process.env.npm_package_version` is only populated when launched via `npm`
+// scripts, which isn't the case for `npx zd-mcp-server` or the published bin —
+// reading the file directly works in every launch mode.
+function resolvePackageVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    // Compiled output lives at `dist/tools/index.js`, so `package.json` is
+    // two directories up. The same relative layout is preserved in the
+    // published tarball.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = require(resolve(here, "../../package.json")) as { version?: string };
+    return pkg.version ?? "dev";
+  } catch {
+    return "dev";
+  }
+}
+
+const PKG_VERSION = resolvePackageVersion();
+
 export const ZENDESK_CLIENT_HEADERS: Record<string, string> = {
-  "X-ZD-MCP-Server": "zd-mcp-server",
+  "User-Agent": `zd-mcp-server/${PKG_VERSION}`,
 };
 
 // Types for exported functions


### PR DESCRIPTION
## Summary
1. Replaces the `X-ZD-MCP-Server` custom header (added in #6) with an override of the request `User-Agent`
2. Bumps the package version to `0.6.1`.

## Implementation notes
- Version is resolved at runtime by reading the bundled `package.json` via `createRequire` + `import.meta.url`. `process.env.npm_package_version` is unreliable because it's only set when launched via npm scripts (not for `npx zd-mcp-server` or direct bin execution).
- Falls back to `zd-mcp-server/dev` if the lookup fails.

## Test plan
- `npx vitest run` — 3/3 pass (assertions updated to check the `User-Agent` value)
- Smoke test running the compiled `dist/tools/index.js` directly (no npm env) outputs:
  ```
  { 'User-Agent': 'zd-mcp-server/0.6.1' }
  ```